### PR TITLE
Fix not shutting services down before exit

### DIFF
--- a/rootfs/services/.s6-svscan/finish
+++ b/rootfs/services/.s6-svscan/finish
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Make sure all services have actually exited *completely*
+for svc in /services/[a-z]*; do [ -d "$svc" ] && s6-svc -d -wD "$svc"; done
+
 # Remove leftover pid files from a stop/start
 rm -rf /var/run/*.pid /var/run/*/*.pid
 


### PR DESCRIPTION
This fixes the rspamd stats problem, and hopefully prevents similar issues with other daemons.  The issue was that as written, the `finish` script simply exited without first terminating any of the running services, which in rspamd's case meant it never saved its stats.  The change requests each service exit and *waits* for that service's `finish` to complete before exiting the overall container process.  And it fixes the rspamd stats problem.